### PR TITLE
add width property to img elements to stop overflow

### DIFF
--- a/Product Landing Page/LandingPage.css
+++ b/Product Landing Page/LandingPage.css
@@ -100,7 +100,7 @@ h1 {
     background-repeat: no-repeat;
     background-size: cover;
     background-position: center;
-    min-height: 400px;  
+    min-height: 400px; 
 }
 
 h2 {
@@ -113,6 +113,7 @@ h2 {
     display: flex;
     order: 2;
     width: 100%; /* added this to make sure your title img fills it's container */
+    height: 100%;
 }
 
 #product-lineup {
@@ -120,8 +121,14 @@ h2 {
 
 }
 
+#product-lineup > video {
+    width: 100%;
+    height: auto;
+}
+
 #product-img {
     width: 100%; /* added this to make sure your product img fills it's container */
+    height: 100%;
 }
 
 @media (prefers-reduced-motion: no-preference) {

--- a/Product Landing Page/LandingPage.css
+++ b/Product Landing Page/LandingPage.css
@@ -100,7 +100,7 @@ h1 {
     background-repeat: no-repeat;
     background-size: cover;
     background-position: center;
-    min-height: 400px;
+    min-height: 400px;  
 }
 
 h2 {
@@ -112,11 +112,16 @@ h2 {
 #title-img {
     display: flex;
     order: 2;
+    width: 100%; /* added this to make sure your title img fills it's container */
 }
 
 #product-lineup {
     display: flex;
 
+}
+
+#product-img {
+    width: 100%; /* added this to make sure your product img fills it's container */
 }
 
 @media (prefers-reduced-motion: no-preference) {


### PR DESCRIPTION
I think I fixed the overflow problem you were having with the images. I added `width: 100%` to the image elements so that they could fill the containers the inhabit. 

In terms of responsiveness, I think you're going to run into a similar overflow issue with the header and navbar section when viewed on smaller screens. I'm not sure if you've learned about mobile-first design or building responsive websites yet, but this is something could be addressed by using media queries and relative units. 